### PR TITLE
Fix catch crash

### DIFF
--- a/CLAMScatch.py
+++ b/CLAMScatch.py
@@ -1255,6 +1255,7 @@ class CLAMSCatch(QDialog, ui_CLAMSCatch.Ui_clamsCatch):
 
         #  update the tables
         self.updateTables()
+        self.activeSpcName = None
 
 
     def transferSample(self):

--- a/CLAMScatch.py
+++ b/CLAMScatch.py
@@ -1249,13 +1249,13 @@ class CLAMSCatch(QDialog, ui_CLAMSCatch.Ui_clamsCatch):
                         self.survey+" AND event_id="+self.activeHaul+" AND sample_id = "+
                         self.activeSampleKey)
                 self.db.dbExec(sql)
+                self.activeSpcName = None
 
             #  refresh the species list
             self.reloadSamplesList()
 
         #  update the tables
         self.updateTables()
-        self.activeSpcName = None
 
 
     def transferSample(self):


### PR DESCRIPTION
the fix in this PR clears activeSpcName (the species selection) after deletion of a species.
previously, when a new species was deleted the species selection was not cleared, so a user could enter a manual weight for a species that no longer existed - which causes the app to crash.