### PR TITLE
fix conditional button color update

### DIFF
--- a/CLAMSspecimen.py
+++ b/CLAMSspecimen.py
@@ -1042,7 +1042,12 @@ class CLAMSSpecimen(QDialog, ui_CLAMSSpecimen.Ui_clamsSpecimen):
                     btn.setStyleSheet("background-color: gray")
                 if len(self.buttonEnable[i]) > 1 and self.buttonEnable[i][1]:
                     self.forcing[i] = '1'
-                    btn.setStyleSheet("background-color: red")
+                    #Only turn the button red if a measurement hasn't been taken yet.
+                    # Otherwise, ensure it stays green.
+                    if self.values[i] is None:
+                        btn.setStyleSheet("background-color: red")
+                    else:
+                        btn.setStyleSheet("background-color: green")
 
 
     def getNext(self, skipChecks=False):


### PR DESCRIPTION
We have a conditional that turns a button (Otolith) red when a fish is a certain length. The button updates to red when a length measurement is taken, and then turns green when a barcode is scanned. However, if another measurement is taken after Otolith (such as a DNA barcode), the Otolith button turns back red even though a measurement exists. I used AI to help be debug and add a small piece of code to ensure the button stays green if a measurement type exists. 